### PR TITLE
Fix metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ass-to-vtt
 
-Based on @mafintosh's work on srt-to-vtt
+Based on @mafintosh's work on [srt-to-vtt](https://github.com/mafintosh/srt-to-vtt).
 
 Transform stream that converts ass files to vtt files.
 vtt files are used to provide subtitles in html5 video

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jamiees2/srt-to-vtt.git"
+    "url": "https://github.com/jamiees2/ass-to-vtt.git"
   },
   "author": "James Sigurdarson (@jamiees2)",
   "license": "MIT",


### PR DESCRIPTION
Don't forget to publish the changes to npm so that the repository link at https://www.npmjs.com/package/ass-to-vtt points to your repo instead of a non-existing repo.
