### PR TITLE
Smaller header (WEBVTT FILE->WEBVTT) per the spec

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ module.exports = function() {
   }
 
   var parse = through.obj(write)
-  parse.push('WEBVTT FILE\r\n\r\n')
+  parse.push('WEBVTT\r\n\r\n')
   return pumpify(split(), parse)
 }
 


### PR DESCRIPTION
WEBVTT spec says [the first line only requires "WEBVTT" string](https://w3c.github.io/webvtt/#file-structure), and then some optional characters:

>Optionally, either a U+0020 SPACE character or a U+0009 CHARACTER TABULATION (tab) character followed by any number of characters that are not U+000A LINE FEED (LF) or U+000D CARRIAGE RETURN (CR) characters.

`WEBVTT FILE` is allowed but not strictly required, so I'm proposing removing the word FILE.